### PR TITLE
Add basic eventType handling as well as steals and walks

### DIFF
--- a/Cauldron/GameEvent.cs
+++ b/Cauldron/GameEvent.cs
@@ -6,6 +6,29 @@ using System.Threading.Tasks;
 
 namespace Cauldron
 {
+    public static class GameEventType
+    {
+        public static string UNKNOWN = "UNKNOWN";
+        public static string NONE = "NONE";
+        public static string OUT = "OUT";
+        public static string STRIKEOUT = "STRIKEOUT";
+        public static string STOLEN_BASE = "STOLEN_BASE";
+        public static string CAUGHT_STEALING = "CAUGHT_STEALING";
+        public static string PICKOFF = "PICKOFF";
+        public static string WILD_PITCH = "WILD_PITCH";
+        public static string BALK = "BALK";
+        public static string OTHER_ADVANCE = "OTHER_ADVANCE";
+        public static string WALK = "WALK";
+        public static string INTENTIONAL_WALK = "INTENTIONAL_WALK";
+        public static string HIT_BY_PITCH = "HIT_BY_PITCH";
+        public static string FIELDERS_CHOICE = "FIELDERS_CHOICE";
+        public static string SINGLE = "SINGLE";
+        public static string DOUBLE = "DOUBLE";
+        public static string TRIPLE = "TRIPLE";
+        public static string HOME_RUN = "HOME_RUN";
+    }
+
+
     /// <summary>
     /// Serializable class following DB schema from SIBR for baserunning info
     /// </summary>
@@ -64,6 +87,8 @@ namespace Cauldron
         public string additionalContext { get; set; }
         public bool topOfInning { get; set; }
         public List<string> eventText { get; set; }
+        public bool isSteal { get; set; }
+        public bool isWalk{ get; set; }
         public override string ToString()
         {
             return $"[{eventIndex}] OB: {outsBeforePlay}\tO: {outsOnPlay}\tCount {totalBalls}-{totalStrikes}\tFouls: {totalFouls}\tBases: {basesHit}\tRBIs: {runsBattedIn}\t\"{additionalContext}\": {pitcherId} pitching to {batterId}";

--- a/README.md
+++ b/README.md
@@ -8,19 +8,18 @@ Run from the command line:
 ## TODO
 
 * Handle partial games by ignoring them and printing a warning
-* Handle steals
-	* Steals should emit the current apperance so far, ended by the steal
-	* We should then start a new event for the rest of that appearance
 
 ## Unimplemented Fields
 
-* `eventType`
 * `pitchesList`
 * `isLeadoff`
 * `lineupPosition`
 * `battedBallType`
 * `baseRunners`
 	* This is an array of `GameEventBaseRunner` sub-objects that aren't yet implemented
+
+## Partially implemented fields
+* `eventType`
 
 ## Known Wrong Fields
 


### PR DESCRIPTION
If you have already implemented this and not pushed it, feel free to disregard.

## Changes
- Added eventTypes from the DB schema and implemented as many as I could find in the game logs. (there were some I didn't see, like balks and wild pitches for instance).
- Updated walks and steals to emit and end the event.
- Updated RBI calculation to ignore stealing home.

## How Was This Tested
I ran this against some of the json files locally and manually spot checked the records in the output. As far as I can tell, everything (that was implemented) seemed to be correct.