### PR TITLE
Fix STRIKOUT eventType to work for both looking and swinging

### DIFF
--- a/Cauldron/GameEventParser.cs
+++ b/Cauldron/GameEventParser.cs
@@ -185,7 +185,7 @@ namespace Cauldron
 			// Out
 			if(newState.lastUpdate.Contains("out") || newState.lastUpdate.Contains("sacrifice") || newState.lastUpdate.Contains("hit into a double play"))
 			{
-				if(newState.lastUpdate.Contains("strikes out"))
+				if(newState.lastUpdate.Contains("strikes out") || newState.lastUpdate.Contains("struck out"))
 				{
 					m_currEvent.eventType = GameEventType.STRIKEOUT;
 				}


### PR DESCRIPTION
Didn't realize the wording was different for strikeouts looking vs swinging. Tested this locally and it fixes that issue.